### PR TITLE
Use the equals form for the job arguments

### DIFF
--- a/.github/workflows/gcp-run-cloud-run-job.yml
+++ b/.github/workflows/gcp-run-cloud-run-job.yml
@@ -49,4 +49,4 @@ jobs:
         run: |-
           gcloud run jobs execute "${{ inputs.name }}" \
             --region "${{ inputs.region }}" \
-            --args '${{ inputs.args }}' --wait
+            --args='${{ inputs.args }}' --wait


### PR DESCRIPTION
`gcloud run jobs execute --args '<value>'` rejects a value with a leading dash (`argument --args: expected one argument`), because argparse reads it as a new flag. Passing `args: -m,app.main` through `gcp-run-cloud-run-job.yml` therefore fails before an execution is created. The equals form accepts leading dashes.
